### PR TITLE
Alter 'NDEF message not found on tag' alert to be more user friendly

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -127,7 +127,7 @@ const OpenSpool = () => {
         setMinTemp(jsonValue.min_temp.toString());
         setMaxTemp(jsonValue.max_temp.toString());
       } else {
-        Alert.alert('No NDEF message found on the tag.');
+        Alert.alert('Empty tag detected.');
       }
     } catch (ex) {
       console.warn('NFC read failed - could be user or system failure', ex);


### PR DESCRIPTION
Fixes #18

Altered the alert,

> 'No NDEF message found on the tag'

to instead read,

> 'Empty tag detected'

to make the alert more user friendly (users shouldn't need to know what an NDEF message is).