### PR TITLE
Create interlock to prevent user from selecting a max temp that is lower than min temp

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -289,7 +289,7 @@ const OpenSpool = () => {
               <Dropdown
                 style={styles.dropdown}
                 containerStyle={styles.dropdownContainer}
-                data={temperatures.slice(3)}
+                data={temperatures.filter(temp => parseInt(temp.value) >= parseInt(minTemp))}
                 labelField="label"
                 valueField="value"
                 placeholder="Max temp"


### PR DESCRIPTION
Fix for Issue #8

Added a filter for the Max Temp dropdown to display only temperatures that are equal to or greater than minTemp.