### PR TITLE
Update maxTemp dropdown to only show options greater than minTemp

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -289,7 +289,7 @@ const OpenSpool = () => {
               <Dropdown
                 style={styles.dropdown}
                 containerStyle={styles.dropdownContainer}
-                data={temperatures.filter(temp => parseInt(temp.value) >= parseInt(minTemp))}
+                data={temperatures.filter(temp => parseInt(temp.value) > parseInt(minTemp))}
                 labelField="label"
                 valueField="value"
                 placeholder="Max temp"


### PR DESCRIPTION
Small change to the logic for the maxTemp dropdown so that only values greater than minTemp are selectable.

This fixes issue #22 by preventing the selection of maxTemp values equal to minTemp.