### PR TITLE
Auto-adjust maxTemp when minTemp is set too high

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -90,9 +90,18 @@ const OpenSpool = () => {
   };
 
   const verifyAndSetMinTemp = (temp: string) => {
+      // If the new minTemp is equal or greater than the maxTemp, adjust maxTemp
     if (Number(temp) >= Number(maxTemp)) {
-      Alert.alert('Min temperature must be less than max temperature');
+        const tempPlusStep = Number(temp) + 5;
+        const highestTempValue = Number(temperatures[temperatures.length - 1].value);
+
+        // Ensure maxTemp is always greater than minTemp
+        const newMaxTemp = Math.min(tempPlusStep, highestTempValue);
+
+        setMaxTemp(String(newMaxTemp));
     }
+
+      // Set the new minTemp
     setMinTemp(temp);
   };
 
@@ -269,7 +278,7 @@ const OpenSpool = () => {
               <Dropdown
                 style={styles.dropdown}
                 containerStyle={styles.dropdownContainer}
-                data={temperatures.slice(0, -3)}
+                data={temperatures.slice(0, -1)}
                 labelField="label"
                 valueField="value"
                 placeholder="Min temp"


### PR DESCRIPTION
Updates verifyAndSetMinTemp logic:

If the new minTemp is greater than or equal to maxTemp, adjust maxTemp to be the lower of two values:

1. minTemp + 5 (the next step in temperature), or
2. The highest possible temperature in the array (to avoid exceeding the upper limit).

Also, updates the minTemp dropdown to exclude the highest possible temperature, so that the above logic works as intended. This effectively allows all but the highest temperature in the array to be selected as the minTemp.

This update would allow minTemp to be adjusted freely, and maxTemp to be automatically update when needed.

