### PR TITLE
Update minTemp dropdown so only values less than maxTemp are selectable

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -269,7 +269,7 @@ const OpenSpool = () => {
               <Dropdown
                 style={styles.dropdown}
                 containerStyle={styles.dropdownContainer}
-                data={temperatures.slice(0, -3)}
+                data={temperatures.filter(temp => parseInt(temp.value) < parseInt(maxTemp))}
                 labelField="label"
                 valueField="value"
                 placeholder="Min temp"


### PR DESCRIPTION
Filters values in the min temp dropdown to only display options which are less than max temp.

Similar to #20 and #23, but for min temp instead of max temp.