### PR TITLE
Create default temperature mappings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -75,10 +75,19 @@ const OpenSpool = () => {
     { label: 'Nylon', value: 'nylon' },
   ];
 
-  const temperatures = Array.from({ length: 20 }, (_, i) => ({
+  const temperatures = Array.from({ length: 21 }, (_, i) => ({
     label: `${180 + i * 5}°C`,
     value: (180 + i * 5).toString(),
   }));
+
+  const filamentDefaults = {
+    pla: { minTemp: 190, maxTemp: 240 },
+    petg: { minTemp: 220, maxTemp: 270 },
+    abs: { minTemp: 240, maxTemp: 280 },
+    gpu: { minTemp: 200, maxTemp: 250 },
+    tpu: { minTemp: 200, maxTemp: 250 },
+    nylon: { minTemp: 190, maxTemp: 240 },
+  };
 
   const renderColorItem = (item: any) => {
     return (
@@ -110,6 +119,15 @@ const OpenSpool = () => {
       Alert.alert('Max temperature must be greater than min temperature');
     }
     setMaxTemp(temp);
+  };
+
+  const setTypeAndDefaults = (type: string) => {
+    setType(type);
+    const defaults = filamentDefaults[type];
+    if (defaults) {
+        setMinTemp(String(defaults.minTemp));
+        setMaxTemp(String(defaults.maxTemp));
+    }
   };
 
   async function readNdef() {
@@ -262,7 +280,7 @@ const OpenSpool = () => {
               valueField="value"
               placeholder="Select type"
               value={type}
-              onChange={item => setType(item.value)}
+              onChange={item => setTypeAndDefaults(item.value)}
               placeholderStyle={styles.placeHolder}
               selectedTextStyle={styles.selected}
               renderItem={(item) => (


### PR DESCRIPTION
When filament type is selected, min temp and max temp automatically change to the defaults for that filament type.

Also increased size of temperature array to accommodate the default max temp of ABS (280). Temperature array may need to be increased further to accommodate higher max temps of other filaments.

Assumed PA/PC-CF from the given reference was for Nylon and used those values for the defaults.

Table of defaults I created is incomplete, but can be easily expanded.

Implements #9 