### PR TITLE
Warn users if NFC is not supported or disabled

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -130,7 +130,28 @@ const OpenSpool = () => {
     }
   };
 
+  const checkNfcSupportedAndEnabled = async () => {
+    const isNfcSupported = await NfcManager.isSupported();
+    if (!isNfcSupported) {
+      Alert.alert('NFC is not supported on this device.');
+      return false;
+    }
+
+    const isNfcEnabled = await NfcManager.isEnabled();
+    if (!isNfcEnabled) {
+      Alert.alert('NFC is disabled. Please enable it in your device settings.');
+      return false;
+    }
+
+    return true;
+  };
+
   async function readNdef() {
+  const isNfcReady = await checkNfcSupportedAndEnabled();
+  if (!isNfcReady) {
+    return;
+  }
+
     try {
       if (Platform.OS === 'android') {
         setModalTitle('Read Tag');
@@ -167,6 +188,11 @@ const OpenSpool = () => {
   }
 
   const writeNdef = async () => {
+    const isNfcReady = await checkNfcSupportedAndEnabled();
+    if (!isNfcReady) {
+      return;
+    }
+
     if (Number(minTemp) >= Number(maxTemp)) {
       Alert.alert('Min temperature must be less than max temperature');
       return;


### PR DESCRIPTION
Adds a new function that returns false and alerts user if NFC is not supported or is not enabled.

Function calls are placed at the beginning of the NDEF read and write functions to return them early (not proceed with the read/write respectively) if the check function returns false.

Implements #15 