### PR TITLE
For Android, automatically copy icons in AppIcons directory to res folder

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -113,6 +113,25 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+
+    tasks.preBuild.doLast {
+        def iconSizes = ["mdpi", "hdpi", "xhdpi", "xxhdpi", "xxxhdpi"]
+        def sourceDir = file("${projectDir.getParentFile().getParent()}/AppIcons/android/")
+        def resBaseDir = file("${projectDir}/src/main/res/")
+        iconSizes.each { size ->
+            def sourceSubDir = new File(sourceDir, "mipmap-${size}")
+            def destDir = new File(resBaseDir, "mipmap-${size}")
+            if (!destDir.exists()) {
+                destDir.mkdirs()
+            }
+            if (sourceSubDir.exists()) {
+                copy {
+                    from sourceSubDir
+                    into destDir
+                }
+            }
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Added preBuild task to automate icon copying in gradle.build for Android.

Automatically copies the icons in the root AppIcons subdirectories (e.g., mipmap-mdpi, mipmap-hdpi, etc.) to the respective locations in the Android resources directory.

Basically centralizes the icons to AppIcons so that one doesn't need to update them in two places.

Doesn't change anything for iOS.

Also assumes the existence (and continued existence) of the AppIcons folder in the root directory, and the android subdirectory within.